### PR TITLE
use suffices to identify hyphenated words

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -1,3 +1,5 @@
+import re
+
 from nltk.corpus import stopwords
 import spacy
 
@@ -18,14 +20,19 @@ class Analyzer(object):
     def preprocess(self, input_string):
         # apply analysis pipeline
         doc = self.nlp(input_string)
-        # there are some suffixes that indicate we don't want hyphen splitting
+        # there are some prefixes that indicate we don't want hyphen splitting
         exceptions = ['anti', 'e', 'extra', 'inter', 'neo', 'non', 'post', 'pre', 'pro']
-        word_indices = [
-            token.i for token in doc if token.text in exceptions
+        # first, check that the prefixes are indeed connected with a hyphen
+        prefixes = [
+            pref for pref in exceptions if '{}-'.format(pref) in input_string.lower()
         ]
-        with doc.retokenize() as retokenizer:
-            for index in word_indices:
-                retokenizer.merge(doc[index:index+3])
+        if len(prefixes):
+            word_indices = [
+                token.i for token in doc if token.text.lower() in prefixes
+            ]
+            with doc.retokenize() as retokenizer:
+                for index in word_indices:
+                    retokenizer.merge(doc[index:index+3])
         output = [self.select_token(token).lower() for token in doc if self.select_token(token)]
         return output
 

--- a/test_analyzer.py
+++ b/test_analyzer.py
@@ -16,3 +16,12 @@ def test_hyphen_merge():
     assert "non-exciting" in output
     assert "e-democracy" in output
     assert len(output) == 6
+
+def test_hyphen_exception():
+    analyzer = Analyzer('english', False).preprocess
+    test_sentence = 'Our post offices are always open.'
+    output = analyzer(test_sentence)
+    assert len(output) == 3
+    test_sentence = 'Post-war London was grim.'
+    output = analyzer(test_sentence)
+    assert 'post-war' in output


### PR DESCRIPTION
In lieu of ignoring hyphens when tokenizing altogether, I now took another approach: identify suffices such as "neo", "anti", etc. which might indicate that splitting should not take place, and merging SpaCy's output accordingly. Close #3 .